### PR TITLE
Allow --genes to accept comma-separated list of genes

### DIFF
--- a/R/cmd_args.R
+++ b/R/cmd_args.R
@@ -624,7 +624,7 @@ function_options <- function(func_names) {
             ),
             make_option(
                 c('--genes'),
-                action = 'store',
+                action = 'callback',
                 type = 'character',
                 default = NULL,
                 metavar = 'STR',

--- a/R/cmd_args.R
+++ b/R/cmd_args.R
@@ -628,8 +628,9 @@ function_options <- function(func_names) {
                 type = 'character',
                 default = NULL,
                 metavar = 'STR',
+                callback = parse_comma_separated_values(),
                 help = paste(
-                    'A list of gene IDs/short names to plot, one per panel.'
+                    'A comma-separated list of gene IDs/short names to plot, one per panel.'
                 )
             ),
             make_option(

--- a/R/cmd_utils.R
+++ b/R/cmd_utils.R
@@ -24,6 +24,14 @@ check_choose_from <- function(choices) {
     }
 }
 
+#' Parse a string of comma-separated values into a vector
+parse_comma_separated_values <- function(sep = ',') {
+    function(opt, opt_flag, opt_value, parser, sep. = sep) {
+        strsplit(opt_value, sep., fixed = T)[[1]]
+    }
+}
+
+
 #' Take a list of options and positional arguments, and parse the command line
 get_opts <- function(arguments, args) {
     k_opts <- sapply(arguments, class) == 'OptionParserOption'

--- a/monocle-scripts-post-install-tests.bats
+++ b/monocle-scripts-post-install-tests.bats
@@ -42,6 +42,7 @@ setup() {
     diffExp_opt="-F tsv --knn 25 --method Moran_I --alternative greater --cores 2"
     diffExp_tbl="${output_dir}/diffExp.tsv"
     plotCells_opt="-F png --xdim 2 --ydim 1 --color-cells-by pseudotime --reduction-method UMAP --cell-size 1 --alpha 0.2"
+    plotCells_opt_multiple_genes=$plotCells_opt" --genes nduo-1,nduo-6,ctb-1"
     plotCells_plt="${output_dir}/plotCells.png"
 
     if [ ! -e "$output_dir" ]; then
@@ -232,6 +233,18 @@ setup() {
 
     echo "$monocle plotCells $plotCells_opt $orderCells_rds $plotCells_plt"
     run $monocle plotCells $plotCells_opt $orderCells_rds $plotCells_plt
+
+    [ "$status" -eq 0 ]
+    [ -f "$plotCells_plt" ]
+}
+
+@test "PlotCells multiple genes" {
+    if [ "$resume" = 'true' ] && [ -f "$plotCells_plt" ]; then
+        skip "$plotCells_plt exists and resume is set to 'true'"
+    fi
+
+    echo "$monocle plotCells $plotCells_opt_multiple_genes $orderCells_rds $plotCells_plt"
+    run $monocle plotCells $plotCells_opt_multiple_genes $orderCells_rds $plotCells_plt
 
     [ "$status" -eq 0 ]
     [ -f "$plotCells_plt" ]

--- a/monocle-scripts-post-install-tests.bats
+++ b/monocle-scripts-post-install-tests.bats
@@ -42,8 +42,9 @@ setup() {
     diffExp_opt="-F tsv --knn 25 --method Moran_I --alternative greater --cores 2"
     diffExp_tbl="${output_dir}/diffExp.tsv"
     plotCells_opt="-F png --xdim 2 --ydim 1 --color-cells-by pseudotime --reduction-method UMAP --cell-size 1 --alpha 0.2"
-    plotCells_opt_multiple_genes=$plotCells_opt" --genes nduo-1,nduo-6,ctb-1"
     plotCells_plt="${output_dir}/plotCells.png"
+    plotCells_opt_multiple_genes="-F png --xdim 2 --ydim 1 --genes nduo-1,nduo-6,ctb-1 --reduction-method UMAP --cell-size 1 --alpha 0.2"
+    plotCells_multi_plt="${output_dir}/plotCells_multiGene.png"
 
     if [ ! -e "$output_dir" ]; then
         mkdir -p $output_dir
@@ -239,15 +240,15 @@ setup() {
 }
 
 @test "PlotCells multiple genes" {
-    if [ "$resume" = 'true' ] && [ -f "$plotCells_plt" ]; then
-        skip "$plotCells_plt exists and resume is set to 'true'"
+    if [ "$resume" = 'true' ] && [ -f "$plotCells_multi_plt" ]; then
+        skip "$plotCells_multi_plt exists and resume is set to 'true'"
     fi
 
-    echo "$monocle plotCells $plotCells_opt_multiple_genes $orderCells_rds $plotCells_plt"
-    run $monocle plotCells $plotCells_opt_multiple_genes $orderCells_rds $plotCells_plt
+    echo "$monocle plotCells $plotCells_opt_multiple_genes $orderCells_rds $plotCells_multi_plt"
+    run $monocle plotCells $plotCells_opt_multiple_genes $orderCells_rds $plotCells_multi_plt
 
     [ "$status" -eq 0 ]
-    [ -f "$plotCells_plt" ]
+    [ -f "$plotCells_multi_plt" ]
 }
 
 # Local Variables:


### PR DESCRIPTION
This PR allows passing multiple genes as a comma-separated string to `--genes` for `plotCells`.